### PR TITLE
feat: Security 및 JWT 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/AuthExceptionHandlerFilter.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/AuthExceptionHandlerFilter.java
@@ -1,0 +1,65 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+// JwtAuthenticationFilter에서 발생한 오류를 처리하는 필터
+@Component
+public class AuthExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private static final String LOGIN_AGAIN_MESSAGE = "다시 로그인 해주세요";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getHttpStatus().value(), errorCode.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException | MalformedJwtException e) {
+            // 토큰의 유효기간 만료 또는 잘못된 토큰
+            setErrorResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } catch (SecurityException e) {
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            // 유효하지 않은 토큰
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    @Data
+    public static class ErrorResponse{
+        private final Integer code;
+        private final String message;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum ErrorCode{
+        INVALID_TOKEN(HttpStatus.UNAUTHORIZED, LOGIN_AGAIN_MESSAGE),
+        EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, LOGIN_AGAIN_MESSAGE);
+
+        private final HttpStatus httpStatus;
+        private final String message;
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/AuthExceptionHandlerFilter.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/AuthExceptionHandlerFilter.java
@@ -1,6 +1,7 @@
 package com.mocamp.mocamp_backend.authentication;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mocamp.mocamp_backend.dto.CommonResponse.ErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -45,12 +46,6 @@ public class AuthExceptionHandlerFilter extends OncePerRequestFilter {
             // 유효하지 않은 토큰
             setErrorResponse(response, ErrorCode.INVALID_TOKEN);
         }
-    }
-
-    @Data
-    public static class ErrorResponse{
-        private final Integer code;
-        private final String message;
     }
 
     @Getter

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        // 인증되지 않은 사용자에 대한 응답
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(
+                new AuthExceptionHandlerFilter.ErrorResponse(HttpStatus.UNAUTHORIZED.value(), "다시 로그인 해주세요")));
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try{
+            // 토큰 값만 추출
+            String token = resolveToken(request);
+            // 토큰이 존재하고, 유효한 토큰이면 인증 객체를 생성한 뒤, SecurityContextHolder 스레드에 등록
+            if(token != null && jwtProvider.validateToken(token)){
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        catch (SecurityException e){
+            throw new SecurityException();
+        }
+        catch (MalformedJwtException e){
+            throw new MalformedJwtException(e.getMessage());
+        }
+        catch(ExpiredJwtException e){
+            throw new ExpiredJwtException(e.getHeader(), e.getClaims(), e.getMessage());
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/JwtProvider.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/JwtProvider.java
@@ -59,20 +59,15 @@ public class JwtProvider {
      * @return 생성된 JWT 토큰
      */
     public String generateToken(Authentication authentication, long expireMills){
-        String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
-
         long now = (new Date()).getTime();
-
         Date accessTokenExpire = new Date(now + expireMills);
-        String token = Jwts.builder()
+
+        return Jwts.builder()
                 .setSubject(authentication.getName())
-                .claim("auth", authorities)
+                .claim("auth", "ROLE_USER") // 고정된 권한
                 .setExpiration(accessTokenExpire)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-        return token;
     }
 
     /**

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/JwtProvider.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/JwtProvider.java
@@ -1,0 +1,150 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Service
+public class JwtProvider {
+
+    private final Key key;
+    // AccessToken 유효기간 : 1일
+    public static final int ACCESS_TOKEN_EXPIRE = 1000 * 60 * 60 * 24;
+    // RefreshToken 유효기간 : 15일
+    public static final int REFRESH_TOKEN_EXPIRE = 1000 * 60 * 60 * 24 * 15;
+
+    /**
+     * 토큰을 파싱하여 Claims 객체를 반환하는 메서드
+     * @param accessToken JWT 액세스 토큰
+     * @return Claims 객체
+     */
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * JwtProvider 생성자
+     * @param secretKey JWT 비밀키를 Base64로 인코딩한 값
+     */
+    public JwtProvider(@Value("${jwt.secretKey}") String secretKey){
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 토큰을 생성하는 메서드
+     * @param authentication 인증 정보 (사용자 이름과 권한 정보)
+     * @param expireMills 토큰 만료 시간 (밀리초 단위)
+     * @return 생성된 JWT 토큰
+     */
+    public String generateToken(Authentication authentication, long expireMills){
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        Date accessTokenExpire = new Date(now + expireMills);
+        String token = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpire)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+        return token;
+    }
+
+    /**
+     * 액세스 토큰을 생성하는 메서드
+     * @param authentication 인증 정보 (사용자 이름과 권한 정보)
+     * @return 생성된 액세스 토큰
+     */
+    public String generateAccessToken(Authentication authentication){
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRE);
+    }
+
+    /**
+     * 리프레시 토큰을 생성하는 메서드
+     * @param authentication 인증 정보 (사용자 이름과 권한 정보)
+     * @return 생성된 리프레시 토큰
+     */
+    public String generateRefreshToken(Authentication authentication){
+        return generateToken(authentication, REFRESH_TOKEN_EXPIRE);
+    }
+
+    /**
+     * JMT 토큰을 복호화해 토큰에 들어있는 정보를 꺼내는 메서드
+     * @param accessToken JWT 토큰
+     */
+    public Authentication getAuthentication(String accessToken){
+        Claims claims = parseClaims(accessToken);
+        if (claims.get("auth") == null ){
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        /**
+         * claim에서 권한 정보 가져오기
+         * @param claim : 토큰을 복호화한 것
+         */
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails pricipal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(pricipal, "", authorities);
+    }
+
+    /**
+     * 토큰의 유효성을 검증하는 메서드
+     * @param token JWT 토큰
+     * @return 토큰이 유효하면 true, 그렇지 않으면 예외를 발생
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException("위조된 토큰");
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredJwtException(e.getHeader(), e.getClaims(), e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("토큰 에러");
+        } catch (io.jsonwebtoken.security.SecurityException e) {
+            throw new SecurityException("security exception");
+        }
+    }
+
+    /**
+     * 비밀키를 Base64로 인코딩하는 메서드
+     * @param secretKey 비밀키
+     * @return Base64로 인코딩된 비밀키
+     */
+    public String encodeBase64SecretKey(@Value("${jwt.secretKey}") String secretKey){
+        return Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/SecurityConfig.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandlerImpl;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // JwtAuthenticationFilter 파트에서 사용하기 위해 주입
+    private final JwtProvider jwtProvider;
+
+    // 로그인 시 인증을 직접 수행하는 Manager 빈으로 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    // SpringSecurity의 필터 체인 관리 등록
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.disable())
+                )
+                .authorizeHttpRequests((auth) -> {
+                            auth.requestMatchers("/healthy").permitAll();
+                            auth.anyRequest().authenticated();
+                        }
+                ).addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new AuthExceptionHandlerFilter(), JwtAuthenticationFilter.class);
+        http.exceptionHandling(manager -> manager.authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .accessDeniedHandler(new AccessDeniedHandlerImpl()));
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/UserDetailsServiceImpl.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/UserDetailsServiceImpl.java
@@ -1,0 +1,58 @@
+package com.mocamp.mocamp_backend.authentication;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.mocamp.mocamp_backend.entity.UserEntity;
+import com.mocamp.mocamp_backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private static final String USER_NOT_FOUND_EXCEPTION = "존재하지 않는 회원입니다.";
+
+    private Collection<? extends GrantedAuthority> getAuthorities(Object user) {
+        // 권한 정보를 GrantedAuthority 객체 컬렉션으로 반환
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    /**
+     * 로그인 시, DB에 있는 사용자 정보와 일치하는지 확인하고 Security가 이해할 수 있는 UserDetails로 반환해주는 메서드
+     * UserDetailsService는 자동으로 작동하되, 이를 Override하여 해당 메서드로 작동하게 구성
+     * @param username
+     * @return UserDetails 객체 반환
+     * @throws UsernameNotFoundException -> DB에 해당 사용자 없으면 예외 처리
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findUserByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException(USER_NOT_FOUND_EXCEPTION));
+        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), getAuthorities(user));
+    }
+
+    /**
+     * JWT 필터에서 인증 성공 후, SecurityContextHolder에 담긴 인증 객체 불러와 요청한 user 찾는 메서드
+     * @return UserEntity
+     */
+    public UserEntity getUserByContextHolder() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        UserDetails userDetails = (UserDetails) principal;
+        return userRepository.findUserByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new UsernameNotFoundException(USER_NOT_FOUND_EXCEPTION));
+    }
+
+    public Authentication getAuthentication(){
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/UserDetailsServiceImpl.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/UserDetailsServiceImpl.java
@@ -30,13 +30,13 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     /**
      * 로그인 시, DB에 있는 사용자 정보와 일치하는지 확인하고 Security가 이해할 수 있는 UserDetails로 반환해주는 메서드
      * UserDetailsService는 자동으로 작동하되, 이를 Override하여 해당 메서드로 작동하게 구성
-     * @param username
+     * @param email
      * @return UserDetails 객체 반환
      * @throws UsernameNotFoundException -> DB에 해당 사용자 없으면 예외 처리
      */
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        UserEntity user = userRepository.findUserByEmail(username)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findUserByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException(USER_NOT_FOUND_EXCEPTION));
         return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), getAuthorities(user));
     }

--- a/src/main/java/com/mocamp/mocamp_backend/dto/CommonResponse/BaseResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/CommonResponse/BaseResponse.java
@@ -1,0 +1,12 @@
+package com.mocamp.mocamp_backend.dto.CommonResponse;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class BaseResponse {
+
+    private Integer code;
+    private String message;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/dto/CommonResponse/ErrorResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/CommonResponse/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.mocamp.mocamp_backend.dto.CommonResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private Integer code;
+    private String message;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/repository/UserRepository.java
+++ b/src/main/java/com/mocamp/mocamp_backend/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.mocamp.mocamp_backend.repository;
+
+import com.mocamp.mocamp_backend.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findUserByEmail(String email);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #3 

---

## 📝 작업 내용
- SecurityConfig 설정 
- JWT 인증 필터 2개 추가(AuthExceptionHandlerFilter, JwtAuthenticationFilter)
- CustomAuthenticationEntryPoint 커스텀  응답 클래스 구현
- JwtProvider 설정
- UserDetailsServiceImpl 구현


---

### 📸 스크린샷(선택)
![스크린샷 2025-04-13 오후 7 58 03](https://github.com/user-attachments/assets/cdbc474f-1d91-43f6-8396-ff548ffed7b3) - 필터 순서, 인증 없이 허용하는 경로 설정, exceptionHandling을 통한 커스텀 에러 응답 메시지 추가 등 구현


![스크린샷 2025-04-13 오후 7 59 34](https://github.com/user-attachments/assets/e6dddd82-5a1a-41a2-b6e4-ac5b055d968d) - 컨트롤러에 가기 전에 JWT를 체크하는 필터, 토큰이 유효하다면 인증 객체를 생성하고, 해당 객체를 SecurityContextHolder에 저장


![스크린샷 2025-04-13 오후 8 02 27](https://github.com/user-attachments/assets/162216e4-6cac-45e4-8425-82dbf30f371a) - JwtAuthenticationFilter에서 오류 발생 시, 위에서 먼저 작동하는 AuthExceptionHandlerFilter에서 예외를 catch하여 Error 응답 메시지를 생성하고 응답


![스크린샷 2025-04-13 오후 8 10 52](https://github.com/user-attachments/assets/091aed9b-1402-4367-a3ef-94d72b8f49b2) - 토큰 자체를 넣지 않고 요청할 시, 에러 응답 메시지를 커스텀화하여 반환해주는 클래스




---

## 🔗 자동 종료 문구(선택)
- Closes #3 