### PR TITLE
fix: 카카오 로그인 페이지 uri 제공하는 방식으로 통일

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
@@ -40,6 +40,15 @@ public class LoginController {
     }
 
     @Operation(
+            summary = "카카오 로그인 페이지 로딩",
+            responses = { @ApiResponse(responseCode = "200", description = "URL 반환 성공") }
+    )
+    @GetMapping("/kakao/page")
+    public ResponseEntity<CommonResponse> loadKakaoLoginPage() {
+        return kakaoLoginService.loadKakaoLoginPage();
+    }
+
+    @Operation(
             summary = "카카오 로그인 리다이렉션 URI",
             parameters = { @Parameter(name = "code", description = "로그인 후 카카오 서버에서 반환하는 코드") }
     )

--- a/src/main/java/com/mocamp/mocamp_backend/service/login/KakaoLoginService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/login/KakaoLoginService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mocamp.mocamp_backend.authentication.JwtProvider;
+import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.SuccessResponse;
 import com.mocamp.mocamp_backend.dto.kakao.KakaoLoginResponse;
 import com.mocamp.mocamp_backend.entity.UserEntity;
 import com.mocamp.mocamp_backend.repository.UserRepository;
@@ -35,6 +37,8 @@ public class KakaoLoginService {
     private String clientId;
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
+    @Value("${kakao.page.uri}")
+    private String pageUri;
 
     /**
      * "인가 코드"로 카카오 "액세스 토큰" 요청하는 메서드
@@ -206,5 +210,18 @@ public class KakaoLoginService {
 
         //3. 카카오ID로 회원가입 & 로그인 처리
         return kakaoUserLogin(kakaoUserInfo);
+    }
+
+    /**
+     * 카카오 로그인 페이지 로드를 위한 uri 제공 메서드
+     * @return 로그인 페이지 uri
+     */
+    public ResponseEntity<CommonResponse> loadKakaoLoginPage() {
+        String uri = pageUri + "?"
+                + "client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&response_type=code";
+
+        return ResponseEntity.ok(new SuccessResponse(200, uri));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #14 

---

## 📝 작업 내용
- 카카오 로그인 버튼을 누르면 로그인 페이지로 이동시키는 방식을 구글 로그인에서 page uri를 제공하는 방식으로 통일했습니다. 
- 네이버도 동일하게 맞출 예정

---

### 📸 스크린샷(선택)
![스크린샷 2025-05-08 오후 6 53 05](https://github.com/user-attachments/assets/23ae51e9-f621-4fa4-9788-d7733f72fce8)
![스크린샷 2025-05-08 오후 6 53 35](https://github.com/user-attachments/assets/6ce9d91f-cc29-4cc8-8b87-ecfc7d66fe29)

---

## 🔗 자동 종료 문구(선택)
- Closes #14 