### PR TITLE
feat: WebSocket 적용 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// Swagger
+	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	// websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mocamp/mocamp_backend/authentication/SecurityConfig.java
+++ b/src/main/java/com/mocamp/mocamp_backend/authentication/SecurityConfig.java
@@ -45,6 +45,10 @@ public class SecurityConfig {
                             auth.requestMatchers("/healthy").permitAll();
                             auth.requestMatchers("/api/login/**").permitAll();
                             auth.requestMatchers("/api-docs/**").permitAll();
+                            auth.requestMatchers("/ws/**").permitAll();
+                            auth.requestMatchers("/ws").permitAll();
+                            auth.requestMatchers("/pub/**").permitAll();
+                            auth.requestMatchers("/sub/**").permitAll();
                             auth.anyRequest().authenticated();
                         }
                 ).addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
@@ -59,6 +63,7 @@ public class SecurityConfig {
         return request -> {
             CorsConfiguration config = new CorsConfiguration();
             config.setAllowedOriginPatterns(List.of("http://localhost:3000", "https://mocamp-front-end.vercel.app/"));
+//            config.setAllowedOriginPatterns(List.of("*"));    // 소켓 테스트용
             config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
             config.setAllowedHeaders(List.of("*"));
             config.setAllowCredentials(true);

--- a/src/main/java/com/mocamp/mocamp_backend/configuration/StompChannelInterceptor.java
+++ b/src/main/java/com/mocamp/mocamp_backend/configuration/StompChannelInterceptor.java
@@ -1,0 +1,31 @@
+package com.mocamp.mocamp_backend.configuration;
+
+import com.mocamp.mocamp_backend.authentication.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompChannelInterceptor implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if(StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String accessToken = accessor.getFirstNativeHeader("Authorization");
+            if(accessToken == null || !jwtProvider.validateToken(accessToken)) {
+                throw new UsernameNotFoundException("Invalid token");
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/configuration/WebSocketConfig.java
+++ b/src/main/java/com/mocamp/mocamp_backend/configuration/WebSocketConfig.java
@@ -1,0 +1,32 @@
+package com.mocamp.mocamp_backend.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final StompChannelInterceptor stompChannelInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompChannelInterceptor);
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/controller/RoomSocketController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/RoomSocketController.java
@@ -1,0 +1,34 @@
+package com.mocamp.mocamp_backend.controller;
+
+import com.mocamp.mocamp_backend.service.room.RoomSocketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class RoomSocketController {
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RoomSocketService roomSocketService;
+
+    @MessageMapping("/video/{roomId}")
+    public void streamVideo(@Header("Authorization") String token,
+                            @DestinationVariable("roomId") Long roomId) {
+        return;
+    }
+
+    @MessageMapping("/audio/{roomId}")
+    public void streamAudio(@Header("Authorization") String token,
+                            @DestinationVariable("roomId") Long roomId) {
+        return;
+    }
+
+    @MessageMapping("/data/notice/{roomId}")
+    public void sendNotice(@Header("Authorization") String token,
+                           @DestinationVariable("roomId") Long roomId) {
+
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/repository/RoomRepository.java
+++ b/src/main/java/com/mocamp/mocamp_backend/repository/RoomRepository.java
@@ -1,0 +1,10 @@
+package com.mocamp.mocamp_backend.repository;
+
+import com.mocamp.mocamp_backend.entity.RoomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<RoomEntity, Long> {
+
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
@@ -1,0 +1,13 @@
+package com.mocamp.mocamp_backend.service.room;
+
+import com.mocamp.mocamp_backend.repository.RoomRepository;
+import com.mocamp.mocamp_backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomSocketService {
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #18 

---

## 📝 작업 내용
- WebSocket 적용을 위한 Config 클래스 구현
- WebSocket 통신용 엔드포인트 Security Filter 예외 허용
- 소켓용 엔드포인트 설계 완료
- STOMP 연결 테스트 완료

---

### 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/79baad57-ac72-40cf-948c-ed67b24ccee9)
- 연결 및 메시지 전송 테스트 완료
- 이 사이트에서는 메시지를 보낼 때 Authorization 헤더를 못 넣기 때문에 실제로 데이터 처리까지 제대로 되는 지는 별도로 나중에 테스트 해봐야 됩니다

![image](https://github.com/user-attachments/assets/f1a5ef30-5378-4024-b198-eaeeb8db5742)
- 웹에서 자체 테스트 돌릴 때 클라이언트 연결이 안 되면 주석처리된 저 부분 활성화해서 Origin 모두 허용해놓고 테스트하면 됩니다

---

## 🔗 자동 종료 문구(선택)
- Closes #18 