### PR TITLE
feat: 로그인 로직 수정 및 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/configuration/RedisConfig.java
+++ b/src/main/java/com/mocamp/mocamp_backend/configuration/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.mocamp.mocamp_backend.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    private final String host;
+    private final int port;
+
+    public RedisConfig(@Value("${spring.data.redis.port}") int port,
+                       @Value("${spring.data.redis.host}") String host){
+        this.port = port;
+        this.host = host;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, ?> redisTemplate(){
+        RedisTemplate<String, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
@@ -29,6 +29,11 @@ public class LoginController {
     private final NaverLoginService naverLoginService;
     private final TokenService tokenService;
 
+    /**
+     * 리프레쉬 토큰을 쿠키에 담는 메서드
+     * @param refreshToken 리프레쉬 토큰
+     * @return 쿠키
+     */
     private Cookie createRefreshTokenCookie(String refreshToken) {
         String cookieName = "refreshToken";
         String cookieValue = refreshToken;
@@ -62,16 +67,7 @@ public class LoginController {
     public ResponseEntity<CommonResponse> loginViaGoogle(@RequestParam(name = "code") String code,
                                                          @RequestParam(name = "redirect_url") String redirectUrl,
                                                          HttpServletResponse response) {
-        System.out.println("asdasd");
-        ResponseEntity<CommonResponse> responseEntity = googleLoginService.logInViaGoogle(code, redirectUrl);
-        CommonResponse body = responseEntity.getBody();
-
-        if (body instanceof SuccessResponse success && success.getMessage() instanceof LoginResult loginResult) {
-            response.addCookie(createRefreshTokenCookie(loginResult.getRefreshToken()));
-            return ResponseEntity.ok(new SuccessResponse(200, new LoginResponse(loginResult.getAccessToken())));
-        }
-
-        return responseEntity;
+        return googleLoginService.logInViaGoogle(code, redirectUrl, response);
     }
 
     @Operation(

--- a/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/LoginController.java
@@ -1,14 +1,20 @@
 package com.mocamp.mocamp_backend.controller;
 
 import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.SuccessResponse;
 import com.mocamp.mocamp_backend.dto.loginResponse.LoginResponse;
+import com.mocamp.mocamp_backend.dto.loginResponse.LoginResult;
 import com.mocamp.mocamp_backend.service.login.GoogleLoginService;
 import com.mocamp.mocamp_backend.service.login.KakaoLoginService;
 import com.mocamp.mocamp_backend.service.login.NaverLoginService;
+import com.mocamp.mocamp_backend.service.login.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +27,18 @@ public class LoginController {
     private final GoogleLoginService googleLoginService;
     private final KakaoLoginService kakaoLoginService;
     private final NaverLoginService naverLoginService;
+    private final TokenService tokenService;
+
+    private Cookie createRefreshTokenCookie(String refreshToken) {
+        String cookieName = "refreshToken";
+        String cookieValue = refreshToken;
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24 * 15);
+        return cookie;
+    }
 
     @Operation(
             summary = "구글 로그인 페이지 로딩",
@@ -41,8 +59,19 @@ public class LoginController {
             responses = { @ApiResponse(responseCode = "200", description = "로그인 성공") }
     )
     @GetMapping("/google/process")
-    public ResponseEntity<CommonResponse> loginViaGoogle(@RequestParam(name = "code") String code, @RequestParam(name = "redirect_url") String redirectUrl) {
-        return googleLoginService.logInViaGoogle(code, redirectUrl);
+    public ResponseEntity<CommonResponse> loginViaGoogle(@RequestParam(name = "code") String code,
+                                                         @RequestParam(name = "redirect_url") String redirectUrl,
+                                                         HttpServletResponse response) {
+        System.out.println("asdasd");
+        ResponseEntity<CommonResponse> responseEntity = googleLoginService.logInViaGoogle(code, redirectUrl);
+        CommonResponse body = responseEntity.getBody();
+
+        if (body instanceof SuccessResponse success && success.getMessage() instanceof LoginResult loginResult) {
+            response.addCookie(createRefreshTokenCookie(loginResult.getRefreshToken()));
+            return ResponseEntity.ok(new SuccessResponse(200, new LoginResponse(loginResult.getAccessToken())));
+        }
+
+        return responseEntity;
     }
 
     @Operation(
@@ -64,9 +93,15 @@ public class LoginController {
             responses = {@ApiResponse(responseCode = "200", description = "로그인 성공 - JWT 토큰 반환")}
     )
     @GetMapping("/kakao/process")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam(name = "code") String code, @RequestParam(name = "redirect_url") String redirect_url) {
-        LoginResponse loginResponse = kakaoLoginService.kakaoLogin(code, redirect_url);
-        return ResponseEntity.ok(loginResponse);
+    public ResponseEntity<CommonResponse> kakaoLogin(@RequestParam(name = "code") String code,
+                                                     @RequestParam(name = "redirect_url") String redirect_url,
+                                                     HttpServletResponse response) {
+        LoginResult loginResult = kakaoLoginService.kakaoLogin(code, redirect_url);
+
+        Cookie refreshTokenCookie = createRefreshTokenCookie(loginResult.getRefreshToken());
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseEntity.ok(new SuccessResponse(200, new LoginResponse(loginResult.getAccessToken())));
     }
 
     @Operation(
@@ -88,8 +123,27 @@ public class LoginController {
             responses = {@ApiResponse(responseCode = "200", description = "로그인 성공 - JWT 토큰 반환")}
     )
     @GetMapping("/naver/process")
-    public ResponseEntity<LoginResponse> naverLogin(@RequestParam(name = "code") String code, @RequestParam(name = "redirect_url") String redirect_url) {
-        LoginResponse loginResponse = naverLoginService.naverLogin(code, redirect_url);
-        return ResponseEntity.ok(loginResponse);
+    public ResponseEntity<CommonResponse> naverLogin(@RequestParam(name = "code") String code,
+                                                     @RequestParam(name = "redirect_url") String redirect_url,
+                                                     HttpServletResponse response) {
+        LoginResult loginResult = naverLoginService.naverLogin(code, redirect_url);
+
+        Cookie refreshTokenCookie = createRefreshTokenCookie(loginResult.getRefreshToken());
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseEntity.ok(new SuccessResponse(200, new LoginResponse(loginResult.getAccessToken())));
     }
+
+    @Operation(
+            summary = "JWT 토큰 재발급",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+                    @ApiResponse(responseCode = "403", description = "리프레시 토큰 불일치 또는 유효하지 않음")
+            }
+    )
+    @PostMapping("/re-issue")
+    public ResponseEntity<CommonResponse> reIssueToken(HttpServletRequest request, HttpServletResponse response) {
+        return tokenService.reIssueToken(request, response);
+    }
+
 }

--- a/src/main/java/com/mocamp/mocamp_backend/dto/commonResponse/SuccessResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/commonResponse/SuccessResponse.java
@@ -1,6 +1,5 @@
 package com.mocamp.mocamp_backend.dto.commonResponse;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/mocamp/mocamp_backend/dto/loginResponse/LoginResult.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/loginResponse/LoginResult.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
-public class LoginResponse {
+public class LoginResult {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/mocamp/mocamp_backend/repository/TokenRepository.java
+++ b/src/main/java/com/mocamp/mocamp_backend/repository/TokenRepository.java
@@ -1,0 +1,51 @@
+package com.mocamp.mocamp_backend.repository;
+
+import com.mocamp.mocamp_backend.authentication.JwtProvider;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class TokenRepository {
+
+    private final long REFRESH_TOKEN_EXPIRE = JwtProvider.REFRESH_TOKEN_EXPIRE;
+    private final String REFRESH_TOKEN_PREFIX = "refreshToken:";
+
+    private RedisTemplate<String, String> redisTemplate;
+    private ValueOperations<String, String> valueOperations;
+
+    public TokenRepository(final RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.valueOperations = redisTemplate.opsForValue();
+    }
+
+    /**
+     * Redis에 유저 ID를 key로 refreshToken을 value로 저장하는 메서드
+     * @param userId 유저 ID
+     * @param refreshToken 리프레쉬 토큰
+     */
+    public void save(Long userId, String refreshToken) {
+        valueOperations.set(REFRESH_TOKEN_PREFIX + userId, refreshToken);
+        redisTemplate.expire(REFRESH_TOKEN_PREFIX + userId, REFRESH_TOKEN_EXPIRE, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 유저 ID로 리프레쉬 토큰 조회하는 메서드
+     * @param userId 유저 ID
+     * @return 리프레쉬 토큰
+     */
+    public String findById(Long userId) {
+        return valueOperations.get(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    /**
+     * 유저 ID로 리프레쉬 토큰 삭제하는 메서드
+     * @param userId 유저 ID
+     */
+    public void deleteById(Long userId) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/login/TokenService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/login/TokenService.java
@@ -1,0 +1,132 @@
+package com.mocamp.mocamp_backend.service.login;
+
+import com.mocamp.mocamp_backend.authentication.JwtProvider;
+import com.mocamp.mocamp_backend.authentication.UserDetailsServiceImpl;
+import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.ErrorResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.SuccessResponse;
+import com.mocamp.mocamp_backend.dto.loginResponse.LoginResponse;
+import com.mocamp.mocamp_backend.dto.loginResponse.LoginResult;
+import com.mocamp.mocamp_backend.entity.UserEntity;
+import com.mocamp.mocamp_backend.repository.TokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private static final String DIFFERENT_REFRESH_TOKEN_EXCEPTION_MESSAGE = "다시 로그인 해주세요";
+    private final JwtProvider jwtProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final TokenRepository tokenRepository;
+
+    /**
+     * Redis에 리프레쉬 토큰 지우는 메서드
+     * @param userId 유저 ID
+     */
+    private void deleteRefreshToken(Long userId) {
+        tokenRepository.deleteById(userId);
+    }
+
+    /**
+     * 쿠키에 담긴 리프레쉬 토큰만 추출하는 메서드
+     * @param request 요청
+     * @return refreshToken 자체의 문자열
+     */
+    private String resolveTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refreshToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * JwtProvider의 토큰 생성 기능을 그대로 사용하기 위해 Authentication 객체를 만드는 메서드
+     * @param email 사용자의 이메일 입력
+     * @return 사용자별 설정 권한이 포함된 Authentication 객체
+     */
+    private Authentication createAuthenticationFromEmail(String email) {
+        return new UsernamePasswordAuthenticationToken(
+                email, // principal - 유저 이메일
+                null, // credentials - 소셜 로그인이므로 별도 비밀번호 설정 X
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    /**
+     * LoginResult 응답 객체를 생성하는 메서드
+     * @param accessToken 생성한 액세스 토큰
+     * @param refreshToken 생성한 리프레쉬 토큰
+     * @return 응답 객체 반환
+     */
+    private LoginResult createLoginResult(String accessToken, String refreshToken) {
+        return LoginResult.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    /**
+     * 리프레쉬 토큰을 쿠키에 담아주는 메서드
+     * @param refreshToken 리프레쉬 토큰
+     * @return 리프레쉬 토큰 담긴 쿠키
+     */
+    private Cookie createRefreshTokenCookie(String refreshToken) {
+        String cookieName = "refreshToken";
+        String cookieValue = refreshToken;
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(1000 * 60 * 60 * 24 * 15);
+        return cookie;
+    }
+
+    /**
+     * 리프레쉬 토큰을 받아 재발급 하는 메서드
+     * @param request 요청
+     * @param response 응답
+     * @return CommonResponse 응답 객체
+     */
+    public ResponseEntity<CommonResponse> reIssueToken(HttpServletRequest request, HttpServletResponse response) {
+        UserEntity user = userDetailsService.getUserByContextHolder();
+
+        // 쿠키에 담긴 리프레쉬 토큰과 Redis에 저장된 리프레쉬 토큰을 꺼내 일치하는지 확인
+        String refreshToken = resolveTokenFromCookies(request);
+        String refreshTokenInRedis = tokenRepository.findById(user.getUserId());
+
+        if (refreshTokenInRedis == null || !refreshTokenInRedis.equals(refreshToken)) {
+            deleteRefreshToken(user.getUserId());
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(new ErrorResponse(403, DIFFERENT_REFRESH_TOKEN_EXCEPTION_MESSAGE));
+        }
+
+        // 일치하면 새로운 액세스 토큰과 리프레쉬 토큰 생성
+        Authentication authentication = createAuthenticationFromEmail(user.getEmail());
+        String newAccessToken = jwtProvider.generateAccessToken(authentication);
+        String newRefreshToken = jwtProvider.generateRefreshToken(authentication);
+        tokenRepository.save(user.getUserId(), newRefreshToken);
+
+        LoginResult loginResult = createLoginResult(newAccessToken, newRefreshToken);
+
+        Cookie refreshTokenCookie = createRefreshTokenCookie(loginResult.getRefreshToken());
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseEntity.ok(new SuccessResponse(200, new LoginResponse(loginResult.getAccessToken())));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #32 

---

## 📝 작업 내용
- 리프레쉬 토큰 반환 시, 쿠키에 담아서 반환하는 것으로 통일 
- 토큰 만료 시, 리프레쉬 토큰 기반으로 토큰 재발급 로직 구현

---

### 📸 스크린샷(선택)


---

## 🔗 자동 종료 문구(선택)
- Closes #32 