### PR TITLE
[Feature] 방장 위임 기능 구현

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/controller/RoomSocketController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/RoomSocketController.java
@@ -1,5 +1,6 @@
 package com.mocamp.mocamp_backend.controller;
 
+import com.mocamp.mocamp_backend.dto.delegation.DelegationUpdateRequest;
 import com.mocamp.mocamp_backend.dto.goal.GoalCompleteUpdateRequest;
 import com.mocamp.mocamp_backend.dto.goal.GoalListRequest;
 import com.mocamp.mocamp_backend.dto.notice.NoticeUpdateRequest;
@@ -52,6 +53,11 @@ public class RoomSocketController {
     @MessageMapping("/data/resolution/{roomId}")
     public void UpdateResolution(@Payload ResolutionUpdateRequest resolutionUpdateRequest, @DestinationVariable("roomId") Long roomId, Principal principal) {
         roomSocketService.UpdateResolution(resolutionUpdateRequest, roomId, principal);
+    }
+
+    @MessageMapping("/data/delegation/{roomId}")
+    public void UpdateDelegation(@Payload DelegationUpdateRequest delegationUpdateRequest, @DestinationVariable("roomId") Long roomId, Principal principal) {
+        roomSocketService.UpdateDelegation(delegationUpdateRequest, roomId, principal);
     }
 
 }

--- a/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateRequest.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.mocamp.mocamp_backend.dto.delegation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DelegationUpdateRequest {
+
+    private Long newAdminId;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateResponse.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DelegationUpdateResponse {
     private WebsocketMessageType type;
-    private Long previousAdminId;
-    private Long newAdminId;
+    private String previousAdminUsername;
+    private String newAdminUsername;
 }

--- a/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/delegation/DelegationUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.mocamp.mocamp_backend.dto.delegation;
+
+import com.mocamp.mocamp_backend.dto.websocket.WebsocketMessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DelegationUpdateResponse {
+    private WebsocketMessageType type;
+    private Long previousAdminId;
+    private Long newAdminId;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/dto/websocket/WebsocketMessageType.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/websocket/WebsocketMessageType.java
@@ -7,5 +7,6 @@ public enum WebsocketMessageType {
     NOTICE_UPDATED,
     RESOLUTION_UPDATED,
     USER_ENTER_UPDATED,
+    ADMIN_UPDATED,
 
 }

--- a/src/main/java/com/mocamp/mocamp_backend/entity/JoinedRoomEntity.java
+++ b/src/main/java/com/mocamp/mocamp_backend/entity/JoinedRoomEntity.java
@@ -48,4 +48,5 @@ public class JoinedRoomEntity {
     private RoomEntity room;
 
     public void updateResolution(String resolution) {this.resolution = resolution;}
+    public void updateIsAdmin(Boolean isAdmin) {this.isAdmin = isAdmin;}
 }

--- a/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
@@ -154,7 +154,7 @@ public class RoomSocketService {
             return;
         }
 
-        log.info("[방장 위임 요청] userId: {} --> userId: {}으로 방장 위임" ,user.getUserId(), delegationUpdateRequest.getUserId());
+        log.info("[방장 위임 요청] userId: {} --> userId: {}으로 방장 위임" ,user.getUserId(), delegationUpdateRequest.getNewAdminId());
 
         // roomId에 해당하는 방이 존재하는지 확인
         RoomEntity roomEntity = roomRepository.findById(roomId).orElse(null);
@@ -187,15 +187,15 @@ public class RoomSocketService {
         }
 
         // 위임을 받을 유저 ID에 방장 권한 부여
-        JoinedRoomEntity delegatedJoinedRoomEntity = joinedRoomRepository.findByRoom_RoomIdAndUser_UserIdAndIsParticipatingTrue(roomId, delegationUpdateRequest.getUserId()).orElse(null);
+        JoinedRoomEntity delegatedJoinedRoomEntity = joinedRoomRepository.findByRoom_RoomIdAndUser_UserIdAndIsParticipatingTrue(roomId, delegationUpdateRequest.getNewAdminId()).orElse(null);
         delegatedJoinedRoomEntity.updateIsAdmin(true);
-        log.info("[새로운 방장으로 변경] 새로운 방장 - userId: {}", delegationUpdateRequest.getUserId());
+        log.info("[새로운 방장으로 변경] 새로운 방장 - userId: {}", delegationUpdateRequest.getNewAdminId());
 
         // 위임을 전달할 유저 ID는 방장 권한 해제
         joinedRoomEntity.updateIsAdmin(false);
         log.info("[기존 방장은 참여자로 변경] 방장 -> 참여자 - userId: {}", user.getUserId());
 
         // WebSocket 응답 전송
-        messagingTemplate.convertAndSend("/sub/data/" + roomId , new DelegationUpdateResponse(WebsocketMessageType.ADMIN_UPDATED, user.getUserId(), delegationUpdateRequest.getUserId()));
+        messagingTemplate.convertAndSend("/sub/data/" + roomId , new DelegationUpdateResponse(WebsocketMessageType.ADMIN_UPDATED, user.getUserId(), delegationUpdateRequest.getNewAdminId()));
     }
 }

--- a/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/room/RoomSocketService.java
@@ -191,11 +191,14 @@ public class RoomSocketService {
         delegatedJoinedRoomEntity.updateIsAdmin(true);
         log.info("[새로운 방장으로 변경] 새로운 방장 - userId: {}", delegationUpdateRequest.getNewAdminId());
 
+        // 위임을 전달받은 유저 이름 추출
+        String delegatedUsername = delegatedJoinedRoomEntity.getUser().getUsername();
+
         // 위임을 전달할 유저 ID는 방장 권한 해제
         joinedRoomEntity.updateIsAdmin(false);
         log.info("[기존 방장은 참여자로 변경] 방장 -> 참여자 - userId: {}", user.getUserId());
 
         // WebSocket 응답 전송
-        messagingTemplate.convertAndSend("/sub/data/" + roomId , new DelegationUpdateResponse(WebsocketMessageType.ADMIN_UPDATED, user.getUserId(), delegationUpdateRequest.getNewAdminId()));
+        messagingTemplate.convertAndSend("/sub/data/" + roomId , new DelegationUpdateResponse(WebsocketMessageType.ADMIN_UPDATED, user.getUsername(), delegatedUsername));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #95 

---

## 📝 작업 내용
- 방장 위임 기능 구현
- Response 시, 웹소캣 채널로 기존 방장과 새로운 방장 유저 이름 반환 

---

### 📸 스크린샷(선택)

---

## 🔗 자동 종료 문구(선택)