### PR TITLE
[Feature] 방 퇴장 시, 방장 랜덤 위임 기능 및 방 종료 30,20,10분 전 종료 알림 기능 구현

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/controller/RoomHttpController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/RoomHttpController.java
@@ -51,14 +51,13 @@ public class RoomHttpController {
             summary = "모캠프 방 퇴장",
             parameters = {
                     @Parameter(name = "Authorization", description = "Jwt 토큰", required = true),
-                    @Parameter(name = "roomId", description = "퇴장하고자 하는 방 ID", required = true),
-                    @Parameter(name = "nextAdminId", description = "방장을 위임할 참가자의 ID", required = false)
+                    @Parameter(name = "roomId", description = "퇴장하고자 하는 방 ID", required = true)
             },
             responses = { @ApiResponse(responseCode = "200", description = "퇴장 성공") }
     )
     @PostMapping("/exit/{roomId}")
-    public ResponseEntity<CommonResponse> exitRoom(@PathVariable Long roomId, @RequestHeader Long nextAdminId) {
-        return roomHttpService.exitRoom(roomId, nextAdminId);
+    public ResponseEntity<CommonResponse> exitRoom(@PathVariable Long roomId) {
+        return roomHttpService.exitRoom(roomId);
     }
 
     // 방 수정 API 필요 시 개발 예정 (WF 상 수정 로직 불필요)

--- a/src/main/java/com/mocamp/mocamp_backend/dto/alert/AlertResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/alert/AlertResponse.java
@@ -1,0 +1,15 @@
+package com.mocamp.mocamp_backend.dto.alert;
+
+import com.mocamp.mocamp_backend.dto.websocket.WebsocketMessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlertResponse {
+
+    private WebsocketMessageType type;
+    private int minutesLeft;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/dto/websocket/WebsocketMessageType.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/websocket/WebsocketMessageType.java
@@ -8,5 +8,6 @@ public enum WebsocketMessageType {
     RESOLUTION_UPDATED,
     USER_ENTER_UPDATED,
     ADMIN_UPDATED,
+    ROOM_END_ALERT,
 
 }

--- a/src/main/java/com/mocamp/mocamp_backend/repository/RoomRepository.java
+++ b/src/main/java/com/mocamp/mocamp_backend/repository/RoomRepository.java
@@ -15,6 +15,8 @@ public interface RoomRepository extends JpaRepository<RoomEntity, Long> {
 
     Optional<RoomEntity> findByRoomSeq(String roomSeq);
 
+    List<RoomEntity> findAllByStatusTrue();
+
     @Override
     <S extends RoomEntity> S save(S entity);
 }

--- a/src/main/java/com/mocamp/mocamp_backend/service/room/RoomScheduler.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/room/RoomScheduler.java
@@ -1,0 +1,63 @@
+package com.mocamp.mocamp_backend.service.room;
+
+import com.mocamp.mocamp_backend.dto.alert.AlertResponse;
+import com.mocamp.mocamp_backend.dto.websocket.WebsocketMessageType;
+import com.mocamp.mocamp_backend.entity.RoomEntity;
+import com.mocamp.mocamp_backend.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class RoomScheduler {
+
+    private final RoomRepository roomRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // 멀티 쓰레드 환경을 고려하여 안전한 ConcurrentHaspMap 사용
+    // 30분전, 20분전, 10분전 룸 ID를 기반으로 1번만 보내는 것을 보장하기 위해 key 값으로 보관
+    private static final Set<Long> alreadySent30 = ConcurrentHashMap.newKeySet();
+    private static final Set<Long> alreadySent20 = ConcurrentHashMap.newKeySet();
+    private static final Set<Long> alreadySent10 = ConcurrentHashMap.newKeySet();
+
+    /**
+     * 모캠프 방 종료까지 30분전, 20분전, 10분전 마다 종료 알림 보내는 스케쥴러 메서드
+     */
+    @Scheduled(cron = "0 * * * * *") // 매 분마다
+    public void checkRoomEndWarnings() {
+        List<RoomEntity> activeRooms = roomRepository.findAllByStatusTrue();
+        LocalDateTime now = LocalDateTime.now();
+
+        for (RoomEntity room : activeRooms) {
+            LocalDateTime endTime = room.getStartedAt().plusSeconds(room.getDuration().toSecondOfDay());
+            long minutesLeft = ChronoUnit.MINUTES.between(now, endTime);
+
+            if (minutesLeft == 30 && !alreadySent30.contains(room.getRoomId())) {
+                sendAlert(room, 30);
+                alreadySent30.add(room.getRoomId());
+            } else if (minutesLeft == 20 && !alreadySent20.contains(room.getRoomId())) {
+                sendAlert(room, 20);
+                alreadySent20.add(room.getRoomId());
+            } else if (minutesLeft == 10 && !alreadySent10.contains(room.getRoomId())) {
+                sendAlert(room, 10);
+                alreadySent10.add(room.getRoomId());
+            }
+        }
+    }
+
+    /**
+     * 30분전, 20분전, 10분전 마다 웹소캣으로 알림 보내는 메서드
+     * @param room Room 엔티티
+     * @param minutesLeft 30분전 or 20분전 or 10분전
+     */
+    private void sendAlert(RoomEntity room, int minutesLeft) {
+        messagingTemplate.convertAndSend("/sub/data/" + room.getRoomId(), new AlertResponse(WebsocketMessageType.ROOM_END_ALERT, minutesLeft));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #95 

---

## 📝 작업 내용
- 방 퇴장할 때, 마지막 남은 사람일 경우, 아닌 경우로 우선 분기 처리
- 마지막 남은 사람일 경우에는 방 자체를 닫는 로직 처리 진행
- 아닌 경우에서 다시 나가려는 사람이 방장인 경우와 일반 참가자일 경우로 분기 처리
- 아닌 경우에서 방장인 경우 나가면 랜덤으로 다른 사용자에게 방장 위임 후 웹소캣으로 방장 넘김을 보냄
- 아닌 경우에서 일반 참가자일 경우 단순히 나가는 로직 처리
- 스케쥴러 기반으로 방 종료 30분전, 20분전, 10분전을 계산하여 방 종료 알림 웹소캣으로 보내는 기능 구현     

---

### 📸 스크린샷(선택)

---

## 🔗 자동 종료 문구(선택)
- 