### PR TITLE
feat: 마이홈 API 개발 (유저 정보 조회, 목표 리스트 조회, 로그아웃

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/controller/UserController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/UserController.java
@@ -1,0 +1,52 @@
+package com.mocamp.mocamp_backend.controller;
+
+import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
+import com.mocamp.mocamp_backend.service.user.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User Controller (마이홈)", description = "마이홈 메뉴 구성을 위한 HTTP 엔드포인트")
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @Operation(
+            summary = "유저 정보 조회(모캠프 사용 추이 데이터 포함)",
+            parameters = { @Parameter(name = "Authorization", description = "Jwt 토큰", required = true) },
+            responses = { @ApiResponse(responseCode = "200", description = "유저 정보 조회 성공") }
+    )
+    @GetMapping("/profile")
+    public ResponseEntity<CommonResponse> getUserProfile() {
+        return userService.getUserProfile();
+    }
+
+    @Operation(
+            summary = "모캠프 방 별 목표 정보 조회",
+            parameters = {
+                    @Parameter(name = "Authorization", description = "Jwt 토큰", required = true),
+                    @Parameter(name = "roomId", description = "방 ID", required = true)
+            },
+            responses = { @ApiResponse(responseCode = "200", description = "목표 조회 성공") }
+    )
+    @GetMapping("/goal/{roomId}")
+    public ResponseEntity<CommonResponse> getUserGoals(@PathVariable("roomId") Long roomId) {
+        return userService.getUserGoals(roomId);
+    }
+
+    @Operation(
+            summary = "유저 로그아웃",
+            parameters = { @Parameter(name = "Authorization", description = "Jwt 토큰", required = true) },
+            responses = { @ApiResponse(responseCode = "200", description = "로그아웃 성공") }
+    )
+    @PostMapping("/logout")
+    public ResponseEntity<CommonResponse> logout() {
+        return userService.logout();
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/dto/user/UserProfileResponse.java
+++ b/src/main/java/com/mocamp/mocamp_backend/dto/user/UserProfileResponse.java
@@ -1,0 +1,26 @@
+package com.mocamp.mocamp_backend.dto.user;
+
+import com.mocamp.mocamp_backend.service.user.UserGoalData;
+import com.mocamp.mocamp_backend.service.user.UserRoomData;
+import com.mocamp.mocamp_backend.service.user.UserTimeData;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+    private Long userId;
+    private String username;
+    private String imagePath;
+    private Long totalDurationMinute;
+    private Long totalNumberOfGoals;
+    private List<UserRoomData> roomList;
+    private List<UserTimeData> timeList;
+    private List<UserGoalData> goalList;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/repository/JoinedRoomRepository.java
+++ b/src/main/java/com/mocamp/mocamp_backend/repository/JoinedRoomRepository.java
@@ -17,6 +17,8 @@ public interface JoinedRoomRepository extends JpaRepository<JoinedRoomEntity, Lo
 
     boolean existsByRoomAndUser(RoomEntity room, UserEntity user);
 
+    List<JoinedRoomEntity> findAllByUser(UserEntity user);
+
     Optional<JoinedRoomEntity> findByRoomAndUser(RoomEntity room, UserEntity user);
 
     List<JoinedRoomEntity> findAllByRoom(RoomEntity room);
@@ -26,4 +28,6 @@ public interface JoinedRoomRepository extends JpaRepository<JoinedRoomEntity, Lo
     List<JoinedRoomEntity> findByRoom_RoomIdAndIsParticipatingTrue(Long roomId);
 
     boolean existsByRoom_RoomIdAndUser_UserIdAndIsAdminTrue(Long roomId, Long userId);
+
+    JoinedRoomEntity findByUserAndRoom_RoomId(UserEntity user, Long roomId);
 }

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/GoalListData.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/GoalListData.java
@@ -1,0 +1,16 @@
+package com.mocamp.mocamp_backend.service.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalListData {
+    private Long goalId;
+    private String content;
+    private Boolean isCompleted;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserGoalData.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserGoalData.java
@@ -1,0 +1,16 @@
+package com.mocamp.mocamp_backend.service.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserGoalData {
+    private String date;
+    private Long amount;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserRoomData.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserRoomData.java
@@ -1,0 +1,21 @@
+package com.mocamp.mocamp_backend.service.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRoomData {
+    private Long roomId;
+    private String roomName;
+    private LocalDateTime startedAt;
+    private LocalTime duration;
+    private Boolean status;
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserService.java
@@ -1,0 +1,214 @@
+package com.mocamp.mocamp_backend.service.user;
+
+import com.mocamp.mocamp_backend.authentication.UserDetailsServiceImpl;
+import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.ErrorResponse;
+import com.mocamp.mocamp_backend.dto.commonResponse.SuccessResponse;
+import com.mocamp.mocamp_backend.dto.user.UserProfileResponse;
+import com.mocamp.mocamp_backend.entity.JoinedRoomEntity;
+import com.mocamp.mocamp_backend.entity.RoomEntity;
+import com.mocamp.mocamp_backend.entity.UserEntity;
+import com.mocamp.mocamp_backend.repository.JoinedRoomRepository;
+import com.mocamp.mocamp_backend.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+    private final RoomRepository roomRepository;
+    private final JoinedRoomRepository joinedRoomRepository;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    private static final String USER_NOT_FOUND_MESSAGE = "유저정보 조회에 실패했습니다";
+    private static final String ROOM_NOT_FOUND_MESSAGE = "방 데이터 조회에 실패했습니다";
+    private static final String ROOM_LIST_NOT_FOUND_MESSAGE = "방 목록 조회에 실패했습니다";
+
+    // 모캠프 방 별 데이터 생성
+    private UserRoomData makeRoomData(final RoomEntity roomEntity) {;
+        return UserRoomData.builder()
+                .roomId(roomEntity.getRoomId())
+                .roomName(roomEntity.getRoomName())
+                .startedAt(roomEntity.getStartedAt())
+                .duration(roomEntity.getDuration())
+                .status(roomEntity.getStatus())
+                .build();
+    }
+
+    /**
+     * 마이홈에 들어갈 사용자 데이터를 생성하여 반환하는 메서드
+     * 모캠프 사용 추이 부분에 들어갈 시간 데이터와 목표 데이터를 모두 포함한다
+     * @return 참여한 방 목록, 참여 시간, 생성한 목표 리스트를 포함한 사용자의 모든 데이터
+     */
+    public ResponseEntity<CommonResponse> getUserProfile() {
+        UserEntity userEntity;
+        List<JoinedRoomEntity> joinedRoomEntityList;
+        List<UserRoomData> roomList = new ArrayList<>();
+        List<UserTimeData> timeList = new ArrayList<>();
+        List<UserGoalData> goalList = new ArrayList<>();
+        Long totalDurationMinute = 0L;
+        Long totalNumberOfGoals = 0L;
+
+        // 유저 확인
+        try {
+            userEntity = userDetailsService.getUserByContextHolder();
+            log.info("[마이홈 유저 조회 성공] 유저 ID: {}, 닉네임: {}", userEntity.getUserId(), userEntity.getUsername());
+        } catch (Exception e) {
+            log.error("[마이홈 유저 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + USER_NOT_FOUND_MESSAGE));
+        }
+
+        // 모캠프 사용 이력 확인
+        try {
+            joinedRoomEntityList = joinedRoomRepository.findAllByUser(userEntity);
+            log.info("[모캠프 목록 조회 성공] 유저 ID: {}, 닉네임: {}, 모캠프 방 개수: {}", userEntity.getUserId(), userEntity.getUsername(), joinedRoomEntityList.size());
+        } catch (Exception e) {
+            log.error("[모캠프 목록 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + ROOM_LIST_NOT_FOUND_MESSAGE));
+        }
+
+        // 모캠프 방 별 데이터 조회
+        try {
+            for(JoinedRoomEntity joinedRoomEntity : joinedRoomEntityList) {
+                RoomEntity roomEntity;
+                try {
+                    roomEntity = roomRepository.findById(joinedRoomEntity.getJoinedRoomId()).orElseThrow();
+                } catch (Exception e) {
+                    log.error("[방 조회 실패] joinedRoomId : {} \n message : {}", joinedRoomEntity.getJoinedRoomId(), e.getMessage(), e);
+                    throw new RuntimeException();
+                }
+
+                UserRoomData userRoomData = makeRoomData(roomEntity);
+                roomList.add(userRoomData);
+
+                UserTimeData userTimeData = UserTimeData.builder()
+                        .date(roomEntity.getEndedAt().getMonth().toString() + "." + roomEntity.getEndedAt().getDayOfMonth())
+                        .duration((long) (roomEntity.getDuration().getHour() * 60 + roomEntity.getDuration().getMinute()))
+                        .build();
+                timeList.add(userTimeData);
+                totalDurationMinute += userTimeData.getDuration();
+
+                UserGoalData userGoalData = UserGoalData.builder()
+                        .date(roomEntity.getEndedAt().getMonth().toString() + "." + roomEntity.getEndedAt().getDayOfMonth())
+                        .amount((long) joinedRoomEntity.getGoals().size())
+                        .build();
+                goalList.add(userGoalData);
+                totalNumberOfGoals += userGoalData.getAmount();
+
+                log.info("[방 데이터 조회 성공] 유저 닉네임: {}, 방 이름: {}", joinedRoomEntity.getUser().getUsername(), roomEntity.getRoomName());
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + ROOM_NOT_FOUND_MESSAGE));
+        }
+
+        // 날짜별 duration 합산
+        List<UserTimeData> timeListResult = timeList.stream()
+                .collect(Collectors.groupingBy(
+                        UserTimeData::getDate,
+                        Collectors.summingLong(UserTimeData::getDuration)
+                ))
+                .entrySet()
+                .stream()
+                .map(entry -> new UserTimeData(entry.getKey(), entry.getValue()))
+                .toList();
+
+        // 날짜별 goal amount 합산
+        List<UserGoalData> goalListResult = goalList.stream()
+                .collect(Collectors.groupingBy(
+                        UserGoalData::getDate,
+                        Collectors.summingLong(UserGoalData::getAmount)
+                ))
+                .entrySet()
+                .stream()
+                .map(entry -> new UserGoalData(entry.getKey(), entry.getValue()))
+                .toList();
+
+        // 응답 객체 생성
+        UserProfileResponse userProfileResponse = UserProfileResponse.builder()
+                .userId(userEntity.getUserId())
+                .username(userEntity.getUsername())
+                .imagePath(userEntity.getImage().getPath())
+                .totalDurationMinute(totalDurationMinute)
+                .totalNumberOfGoals(totalNumberOfGoals)
+                .roomList(roomList)
+                .timeList(timeListResult)
+                .goalList(goalListResult)
+                .build();
+
+        return ResponseEntity.ok(new SuccessResponse(200, userProfileResponse));
+    }
+
+    /**
+     * 마이홈에서 세부 목표 확인 기능을 선택하면 해당 방에서 생성한 목표 기록을 반환하는 메서드
+     * @return 목표 데이터의 ID, 내용, 달성 여부를 포함한 목표 리스트 반환
+     */
+    public ResponseEntity<CommonResponse> getUserGoals(final Long roomId) {
+        UserEntity userEntity;
+        JoinedRoomEntity joinedRoomEntity;
+
+        // 유저 확인
+        try {
+            userEntity = userDetailsService.getUserByContextHolder();
+            log.info("[마이홈 유저 조회 성공] 유저 ID: {}, 닉네임: {}", userEntity.getUserId(), userEntity.getUsername());
+        } catch (Exception e) {
+            log.error("[마이홈 유저 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + USER_NOT_FOUND_MESSAGE));
+        }
+
+        // ID에 맞는 방 데이터 조회
+        try {
+            joinedRoomEntity = joinedRoomRepository.findByUserAndRoom_RoomId(userEntity, roomId);
+            log.info("[모캠프 목록 조회 성공] 유저 ID: {}, 닉네임: {}, 목표 개수: {}", userEntity.getUserId(), userEntity.getUsername(), joinedRoomEntity.getGoals().size());
+        } catch (Exception e) {
+            log.error("[모캠프 목록 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + ROOM_LIST_NOT_FOUND_MESSAGE));
+        }
+
+        List<GoalListData> goalListData = joinedRoomEntity.getGoals().stream()
+                .map(entry -> new GoalListData(entry.getGoalId(), entry.getContent(), entry.getIsCompleted()))
+                .toList();
+        Map<String, Object> goalListMap = new HashMap<>();
+        goalListMap.put("userId", userEntity.getUserId());
+        goalListMap.put("username", userEntity.getUsername());
+        goalListMap.put("roomId", roomId);
+        goalListMap.put("dataList", goalListData);
+
+        return ResponseEntity.ok(new SuccessResponse(200, goalListMap));
+    }
+
+    /**
+     * 로그아웃 메서드
+     * 추후 고도화 예정
+     */
+    public ResponseEntity<CommonResponse> logout() {
+        UserEntity userEntity;
+        List<JoinedRoomEntity> joinedRoomEntityList;
+
+        // 유저 확인
+        try {
+            userEntity = userDetailsService.getUserByContextHolder();
+            log.info("[마이홈 유저 조회 성공] 유저 ID: {}, 닉네임: {}", userEntity.getUserId(), userEntity.getUsername());
+        } catch (Exception e) {
+            log.error("[마이홈 유저 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + USER_NOT_FOUND_MESSAGE));
+        }
+
+        return ResponseEntity.ok(new SuccessResponse(200, true));
+    }
+}

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserTimeData.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserTimeData.java
@@ -1,0 +1,14 @@
+package com.mocamp.mocamp_backend.service.user;
+
+import lombok.*;
+
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTimeData {
+    private String date;
+    private Long duration;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #74 

---

## 📝 작업 내용
- 마이홈 API 개발 완료
- 유저 정보 조회 및 시간, 목표 달성 개수 계산 로직 구현
- 세부 목표 확인하기 기능을 위한 목표 리스트 조회 기능 구현
- 로그아웃 구현

---

### 📸 스크린샷(선택)
- 귀찮아 생략해.

---

## 🔗 자동 종료 문구(선택)
- Closes #74 