### PR TITLE
feat: 방 종료 시간 도달 시, 방 종료 로직 처리 및 웹소캣 알림 전송 로직 구현

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/service/room/RoomScheduler.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/room/RoomScheduler.java
@@ -2,8 +2,11 @@ package com.mocamp.mocamp_backend.service.room;
 
 import com.mocamp.mocamp_backend.dto.alert.AlertResponse;
 import com.mocamp.mocamp_backend.dto.websocket.WebsocketMessageType;
+import com.mocamp.mocamp_backend.entity.JoinedRoomEntity;
 import com.mocamp.mocamp_backend.entity.RoomEntity;
+import com.mocamp.mocamp_backend.repository.JoinedRoomRepository;
 import com.mocamp.mocamp_backend.repository.RoomRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -26,13 +29,13 @@ public class RoomScheduler {
     private final SimpMessagingTemplate messagingTemplate;
 
     // 멀티 쓰레드 환경을 고려하여 안전한 ConcurrentHaspMap 사용
-    // 30분전, 20분전, 10분전 룸 ID를 기반으로 1번만 보내는 것을 보장하기 위해 key 값으로 보관
+    // 30분전, 10분전 룸 ID를 기반으로 1번만 보내는 것을 보장하기 위해 key 값으로 보관
     private static final Set<Long> alreadySent30 = ConcurrentHashMap.newKeySet();
-    private static final Set<Long> alreadySent20 = ConcurrentHashMap.newKeySet();
     private static final Set<Long> alreadySent10 = ConcurrentHashMap.newKeySet();
+    private final JoinedRoomRepository joinedRoomRepository;
 
     /**
-     * 모캠프 방 종료까지 30분전, 20분전, 10분전 마다 종료 알림 보내는 스케쥴러 메서드
+     * 모캠프 방 종료까지 30분전, 10분전 마다 종료 알림 보내는 스케쥴러 메서드
      */
     @Scheduled(cron = "0 * * * * *") // 매 분마다
     public void checkRoomEndWarnings() {
@@ -48,24 +51,46 @@ public class RoomScheduler {
                 sendAlert(room, 30);
                 log.info("[30분전 종료 알림] - roomId: {}", room.getRoomId());
                 alreadySent30.add(room.getRoomId());
-            } else if (minutesLeft == 20 && !alreadySent20.contains(room.getRoomId())) {
-                sendAlert(room, 20);
-                log.info("[20분전 종료 알림] - roomId: {}", room.getRoomId());
-                alreadySent20.add(room.getRoomId());
             } else if (minutesLeft == 10 && !alreadySent10.contains(room.getRoomId())) {
                 sendAlert(room, 10);
                 log.info("[10분전 종료 알림] - roomId: {}", room.getRoomId());
                 alreadySent10.add(room.getRoomId());
+            } else if(!now.isBefore(endTime)) {
+                expireRoom(room);
+                log.info("[방 종료 알림] - roomId: {}", room.getRoomId());
             }
         }
     }
 
     /**
-     * 30분전, 20분전, 10분전 마다 웹소캣으로 알림 보내는 메서드
+     * 30분전, 10분전 마다 웹소캣으로 알림 보내는 메서드
      * @param room Room 엔티티
-     * @param minutesLeft 30분전 or 20분전 or 10분전
+     * @param minutesLeft 30분전 or 10분전
      */
     private void sendAlert(RoomEntity room, int minutesLeft) {
         messagingTemplate.convertAndSend("/sub/data/" + room.getRoomId(), new AlertResponse(WebsocketMessageType.ROOM_END_ALERT, minutesLeft));
+    }
+
+
+    /**
+     * 방 종료시간에 도달하면 방을 종료시킨 후 알림 보내는 메서드
+     * @param room Room 엔티티
+     */
+    @Transactional
+    public void expireRoom(RoomEntity room) {
+        List<JoinedRoomEntity> joinedRoomList = joinedRoomRepository.findAllByRoom(room);
+        for (JoinedRoomEntity joinedRoom : joinedRoomList) {
+            joinedRoom.setIsDeleted(true);
+            joinedRoom.setIsParticipating(false);
+        }
+
+        room.setStatus(false);
+        room.setIsDeleted(true);
+        room.setRoomNum(0);
+
+        roomRepository.save(room);
+        joinedRoomRepository.saveAll(joinedRoomList);
+
+        messagingTemplate.convertAndSend("/sub/data/" + room.getRoomId(), new AlertResponse(WebsocketMessageType.ROOM_END_ALERT, 0));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

---

## 📝 작업 내용
- 방 종료 30분전, 10분전 2개로 추려서 수정
- 방 종료 유효 시간이 다 됐을 경우, 모든 사용자 퇴장 로직과 방 종료 로직 구현
- 스케쥴러로 지속적으로 파악

---

### 📸 스크린샷(선택)
- 작업 내용에 이미지 설명이 필요한 경우 첨부해주세요

---

## 🔗 자동 종료 문구(선택)
- 이 PR이 머지되면 자동으로 닫힐 이슈가 있다면 아래에 작성해주세요
- `Closes #123` 또는 `Fixes #124` 형식으로 작성