### PR TITLE
Fix/#118

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/controller/UserController.java
+++ b/src/main/java/com/mocamp/mocamp_backend/controller/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User Controller (마이홈)", description = "마이홈 메뉴 구성을 위한 HTTP 엔드포인트")
 @RestController
@@ -48,5 +49,16 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<CommonResponse> logout() {
         return userService.logout();
+    }
+
+    @Operation(
+            summary = "유저 정보 수정(유저 이름 및 프로필 사진)",
+            parameters = { @Parameter(name = "Authorization", description = "Jwt 토큰", required = true) },
+            responses = { @ApiResponse(responseCode = "200", description = "유저 정보 수정 성공") }
+    )
+    @PatchMapping("/modify")
+    public ResponseEntity<CommonResponse> modifyUserProfile(@RequestPart(value = "username", required = false) String username,
+                                                            @RequestPart(value = "image", required = false) MultipartFile imageFile) {
+        return userService.modifyUserProfile(username, imageFile);
     }
 }

--- a/src/main/java/com/mocamp/mocamp_backend/entity/ImageEntity.java
+++ b/src/main/java/com/mocamp/mocamp_backend/entity/ImageEntity.java
@@ -29,4 +29,6 @@ public class ImageEntity {
 
     @OneToOne(mappedBy = "image", cascade = CascadeType.ALL, orphanRemoval = true)
     private RoomEntity room;
+
+    public void updatePath(String path) {this.path = path;}
 }

--- a/src/main/java/com/mocamp/mocamp_backend/entity/UserEntity.java
+++ b/src/main/java/com/mocamp/mocamp_backend/entity/UserEntity.java
@@ -46,4 +46,6 @@ public class UserEntity {
     @OneToOne
     @JoinColumn(name = "image_id", nullable = true)
     private ImageEntity image;
+
+    public void updateUsername(String username) {this.username = username;}
 }

--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserService.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserService.java
@@ -5,34 +5,46 @@ import com.mocamp.mocamp_backend.dto.commonResponse.CommonResponse;
 import com.mocamp.mocamp_backend.dto.commonResponse.ErrorResponse;
 import com.mocamp.mocamp_backend.dto.commonResponse.SuccessResponse;
 import com.mocamp.mocamp_backend.dto.user.UserProfileResponse;
+import com.mocamp.mocamp_backend.entity.ImageEntity;
 import com.mocamp.mocamp_backend.entity.JoinedRoomEntity;
 import com.mocamp.mocamp_backend.entity.RoomEntity;
 import com.mocamp.mocamp_backend.entity.UserEntity;
+import com.mocamp.mocamp_backend.repository.ImageRepository;
 import com.mocamp.mocamp_backend.repository.JoinedRoomRepository;
 import com.mocamp.mocamp_backend.repository.RoomRepository;
+import com.mocamp.mocamp_backend.repository.UserRepository;
+import com.mocamp.mocamp_backend.service.image.ImageType;
+import com.mocamp.mocamp_backend.service.s3.S3Uploader;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UserService {
-    private final RoomRepository roomRepository;
-    private final JoinedRoomRepository joinedRoomRepository;
-    private final UserDetailsServiceImpl userDetailsService;
 
     private static final String USER_NOT_FOUND_MESSAGE = "유저정보 조회에 실패했습니다";
     private static final String ROOM_NOT_FOUND_MESSAGE = "방 데이터 조회에 실패했습니다";
     private static final String ROOM_LIST_NOT_FOUND_MESSAGE = "방 목록 조회에 실패했습니다";
+    private static final String IMAGE_SAVING_MESSAGE = "이미지 저장에 실패했습니다";
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String DirName;
+    private final RoomRepository roomRepository;
+    private final ImageRepository imageRepository;
+    private final JoinedRoomRepository joinedRoomRepository;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
 
     // 모캠프 방 별 데이터 생성
     private UserRoomData makeRoomData(final RoomEntity roomEntity) {;
@@ -210,5 +222,71 @@ public class UserService {
         }
 
         return ResponseEntity.ok(new SuccessResponse(200, true));
+    }
+
+    /**
+     * 유저 프로필 정보 수정하는 메서드
+     * @return
+     */
+    @Transactional
+    public ResponseEntity<CommonResponse> modifyUserProfile(String username, MultipartFile imageFile) {
+        UserEntity userEntity;
+        String imagePath = null;
+
+        // 유저 확인
+        try {
+            userEntity = userDetailsService.getUserByContextHolder();
+            log.info("[마이홈 유저 조회 성공] 유저 ID: {}, 닉네임: {}", userEntity.getUserId(), userEntity.getUsername());
+        } catch (Exception e) {
+            log.error("[마이홈 유저 조회 실패] {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(403, "에러 메시지: " + USER_NOT_FOUND_MESSAGE));
+        }
+
+        // 프로필 변경 사항에 유저 이름 변경이 있을 때, 유저 변경 및 저장
+        if(username != null) {
+            userEntity.updateUsername(username);
+            UserEntity updatedUserEntity = userRepository.save(userEntity);
+            log.info("[프로필 이름 변경 완료] - 변경된 닉네임: {}", updatedUserEntity.getUsername());
+        }
+
+        // 프로필 변경 사항에 유저 프로필 사진 변경이 있을 때, 유저 프로필 사진 변경 및 저장
+        if(imageFile != null && !imageFile.isEmpty()) {
+            try {
+                imagePath = s3Uploader.uploadImage(imageFile, DirName);
+                log.info("[이미지 업로드 성공] 경로: {}", imagePath);
+
+                ImageEntity imageEntity = null;
+
+                // 기존 이미지 엔티티가 존재할 경우
+                if (userEntity.getImage() != null) {
+                    imageEntity = imageRepository.findById(userEntity.getImage().getImageId()).orElse(null);
+
+                    if (imageEntity != null) {
+                        imageEntity.updatePath(imagePath);
+                        imageRepository.save(imageEntity);
+                        log.info("[이미지 경로 업데이트 완료] 이미지 ID: {}", imageEntity.getImageId());
+                    }
+                }
+
+                // 기존 이미지가 없거나 못 찾은 경우 새로 생성
+                if(imageEntity == null) {
+                    imageEntity = ImageEntity.builder()
+                            .type(ImageType.profile)
+                            .path(imagePath)
+                            .build();
+                    ImageEntity newImageEntity = imageRepository.save(imageEntity);
+                    userEntity.setImage(newImageEntity);
+                    log.info("[새 이미지 엔티티 저장 및 연결] 이미지 ID: {}", newImageEntity.getImageId());
+                }
+
+            } catch (Exception e) {
+                log.error("[이미지 저장 실패] {}", e.getMessage(), e);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(new ErrorResponse(403, "에러 메시지: " + IMAGE_SAVING_MESSAGE));
+            }
+        }
+
+        return ResponseEntity.ok(new SuccessResponse(200, "프로필 변경이 완료되었습니다"));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #118 

---

## 📝 작업 내용
- 유저 프로필 이름 및 사진 변경 로직 구현
- 소셜 로그인 시, 프로필 이미지도 받은 뒤, 이미지로 저장하게끔 수정

---

### 📸 스크린샷(선택)

---

## 🔗 자동 종료 문구(선택)