### PR TITLE
refactor: 프로필 데이터 반환 시 날짜별 목표 데이터도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/mocamp/mocamp_backend/service/user/UserGoalData.java
+++ b/src/main/java/com/mocamp/mocamp_backend/service/user/UserGoalData.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 
 @Builder
 @Getter
@@ -13,4 +15,5 @@ import lombok.NoArgsConstructor;
 public class UserGoalData {
     private String date;
     private Long amount;
+    private List<GoalListData> goalList;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 관련된 이슈 번호를 적어주세요 (자동 종료가 필요하면 아래 '자동 종료 문구' 섹션에 작성)
- #127 

---

## 📝 작업 내용
- 목표 데이터도 함께 반환하도록 마이홈 정보 조회 API 수정
---